### PR TITLE
Add:user pageに参加グループへのリンクを追加

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,8 @@
 class GroupsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_group, only: %i[show edit update destroy]
+  before_action :check_leader, only: %i[edit update destroy]
+  before_action :check_member, only: %i[show]
 
   def index
     @groups = Group.all
@@ -51,5 +53,19 @@ class GroupsController < ApplicationController
 
   def set_group
     @group = Group.find(params[:id])
+  end
+
+  # ログインユーザーがグループのリーダーであるかを確認する
+  def check_leader
+    set_group
+    redirect_to group_path(@group), notice: "リーダー以外は編集とか出来ません"\
+    unless Group.check_leader(@group, current_user)
+  end
+
+  # グループメンバー以外はグループ情報を見れないようにする
+  def check_member
+    set_group
+    redirect_to user_path(id: current_user.id), alert: "グループメンバー以外は見れません"\
+    unless Group.check_member(@group, current_user)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
+    @groups = @user.groups.all
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -15,6 +15,15 @@ class Group < ApplicationRecord
     User.find(leader_id)
   end
 
+  def self.check_leader(group, user)
+    leader_id = group.joins.find_by(is_leader: true).user_id
+    user.id == leader_id
+  end
+
+  def self.check_member(group, user)
+    group.users.find_by(name: user.name)
+  end
+
   def self.group_members(group)
     members = []
     join_info = group.joins.where(is_leader: false)

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -11,7 +11,14 @@
       <% end %>
 
       <%= link_to '一覧へ', events_path, class: 'btn btn-primary' %>
-      <%= link_to 'グループ編集', edit_group_path(@group) %>
+      <% if @leader.id == current_user.id %>
+        <%= link_to 'グループ編集', edit_group_path(@group), class: 'btn btn-success' %>
+        <%= link_to 'グループ削除', group_path(@group),
+                                    method: :delete,
+                                    data: { confirm: "タスク「#{@group.name}」を削除します。よろしいですか？" },
+                                    class: 'btn btn-danger' %>
+      <% end %>
     </div>
+    <p><%= @comment %></p>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,8 @@
 <h1>マイページ</h1>
 <p>名前：<%= @user.name %></p>
 <p>メールアドレス：<%= @user.email %></p>
+
+<p>所属グループ一覧</p>
+<% @groups.each do |g| %>
+  <p><%= link_to "#{g.name}", group_path(g) %></p>
+<% end %>


### PR DESCRIPTION
- [x] ユーザーが登録したグループのみを表示

- [x] ログインユーザーが グループリーダーの場合、編集、削除ボタンを表示する

・コントローラー側でもグループリーダー以外による、グループ情報編集、削除を制御
・グループメンバー以外はグループ情報を見れないように制御