### PR TITLE
fix:イベント詳細画面のボタン表示修正

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,6 +1,10 @@
 module UsersHelper
-  def user_apply_event?(user, event)
+  def user_apply_event?(event)
     guest_ids = event.attends.map(&:user_id)
-    guest_ids.include?(user.id)
+    guest_ids.include?(current_user.id)
+  end
+
+  def user_contribute_event?(event)
+    event.user.id == current_user.id
   end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -8,6 +8,7 @@
       <!-- 'no_image.png'は、assets/images内に配置 -->
       <%= image_tag 'no_image.png', class: 'img-fluid', style: 'border: 1px solid lightgray' %>
     <% end %>
+
     <div class="card-body">
       <strong><p>投稿者：<%= @event.user.name %></p></strong>
       <p>イベント名：<%= @event.name %></p>
@@ -23,16 +24,21 @@
       <% @guests.each do |g| %>
         <p><%= g.name %>さん</p>
       <% end %>
+
       <%= link_to '一覧へ', events_path, class: 'btn btn-primary' %>
-      <%= link_to '編集', edit_event_path(@event), class: 'btn btn-success' %>
-      <%= link_to '削除', event_path(@event),
-                          method: :delete,
-                          data: { confirm: "タスク「#{@event.name}」を削除します。よろしいですか？" },
-                          class: 'btn btn-danger' %>
+
+      <!-- イベントの投稿者がログインしている時のみ編集、削除ボタンを表示する -->
+      <% if current_user && user_contribute_event?(@event) %>
+        <%= link_to '編集', edit_event_path(@event), class: 'btn btn-success' %>
+        <%= link_to '削除', event_path(@event),
+                            method: :delete,
+                            data: { confirm: "タスク「#{@event.name}」を削除します。よろしいですか？" },
+                            class: 'btn btn-danger' %>
+      <% end %>
 
       <!-- イベントへの参加（attend create）ボタン -->
       <!-- ログインしていて、イベントに参加申し込みをしている場合、キャンセルボタンを表示する -->
-      <% if current_user && user_apply_event?(current_user,@event)  %>
+      <% if current_user && user_apply_event?(@event)  %>
         <%= link_to '参加キャンセル', attend_path(@attend),
                                           method: :delete, class: 'btn btn-danger' %>
       <% else %>


### PR DESCRIPTION
- [x] 誰が見ても、編集、削除ボタンが表示されるので、投稿者以外にはボタンを
表示しないようにする。

user helperにhelperメソッドを記載して対応
以前に記載したヘルパーメソッドをリファクタリングした