### PR TITLE
add:イベント一覧画面にページネーション機能追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,8 @@ class EventsController < ApplicationController
   before_action :check_contributor, only: %i[edit update destroy]
 
   def index
-    @events = Event.all
+    @q = Event.all
+    @events = @q.page(params[:page])
   end
 
   def show

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,9 @@
 class Event < ApplicationRecord
   mount_uploader :image, ImageUploader
 
+  # kaminariのページネーション設定
+  paginates_per 12
+
   validates :name, presence: true, length: { maximum: 100 }
   with_options presence: true do
     validates :place

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -20,4 +20,9 @@
         </div>
       <% end %>
     </div>
+
+    <div>
+      <%= paginate @events %>
+      <%= page_entries_info @events %>
+    </div>
   </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>


### PR DESCRIPTION
### issue番号
#51 
***
- [x] イベント一覧画面にページネーション機能を追加する

- [x] kaminariを使用して実装

- [x] １画面あたり9件or12件の表示とする

1ページあたり12件の表示とした